### PR TITLE
feat: Add JSON configuration parser

### DIFF
--- a/conv.go
+++ b/conv.go
@@ -16,6 +16,9 @@ import (
 //
 // ToString is used internally by zerocfg for representing option values as strings, including when passing ToString to custom parsers and for rendering configuration output.
 func ToString(v any) string {
+	if v == nil {
+		return "null"
+	}
 	if nv, ok := dereference(v); ok {
 		return ToString(nv)
 	}

--- a/json/parse.go
+++ b/json/parse.go
@@ -1,0 +1,142 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type Parser struct {
+	path *string
+
+	conv    func(any) string
+	awaited map[string]bool
+}
+
+func New(path *string) *Parser {
+	return &Parser{path: path}
+}
+
+func (p *Parser) Type() string {
+	if p.path == nil || *p.path == "" {
+		return "json"
+	}
+	return fmt.Sprintf("json[%s]", *p.path)
+}
+
+func (p *Parser) Parse(keys map[string]bool, conv func(any) string) (found, unknown map[string]string, err error) {
+	found = make(map[string]string)
+	unknown = make(map[string]string)
+
+	if p.path == nil || *p.path == "" {
+		return found, unknown, nil
+	}
+
+	data, err := os.ReadFile(*p.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return found, unknown, nil
+		}
+		return nil, nil, fmt.Errorf("read json file %q: %w", *p.path, err)
+	}
+
+	if len(data) == 0 {
+		return found, unknown, fmt.Errorf("json file %q is empty", *p.path)
+	}
+
+	p.conv = conv
+	p.awaited = keys
+
+	return p.parse(data)
+}
+
+func (p *Parser) parse(data []byte) (found, unknown map[string]string, err error) {
+	var settings any
+
+	tempFile, err := os.CreateTemp("", "json-input-*.json")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create temp file for json: %w", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	if _, err := tempFile.Write(data); err != nil {
+		tempFile.Close()
+		return nil, nil, fmt.Errorf("write to temp file for json: %w", err)
+	}
+	if _, err := tempFile.Seek(0, 0); err != nil {
+		tempFile.Close()
+		return nil, nil, fmt.Errorf("seek temp file for json: %w", err)
+	}
+
+	decoder := json.NewDecoder(tempFile)
+	decoder.UseNumber()
+	decodeErr := decoder.Decode(&settings)
+	closeErr := tempFile.Close()
+
+	if decodeErr != nil {
+		return nil, nil, fmt.Errorf("unmarshal json: %w", decodeErr)
+	}
+	if closeErr != nil {
+		return nil, nil, fmt.Errorf("close temp file for json: %w", closeErr)
+	}
+
+	settingsMap, ok := settings.(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("json root is not an object")
+	}
+
+	found, unknown = p.flatten(settingsMap)
+
+	return found, unknown, nil
+}
+
+func (p *Parser) flatten(settings map[string]any) (found, unknown map[string]string) {
+	found, unknown = make(map[string]string), make(map[string]string)
+	p.flattenDFS(settings, "", found, unknown)
+	return found, unknown
+}
+
+func (p *Parser) flattenDFS(m map[string]any, prefix string, found, unknown map[string]string) {
+	for k, v := range m {
+		newKey := k
+		if prefix != "" {
+			newKey = prefix + "." + k
+		}
+
+		_, isAwaited := p.awaited[newKey]
+
+		if subMap, ok := v.(map[string]any); ok {
+			if isAwaited {
+				found[newKey] = p.conv(v)
+
+			} else {
+
+				isParentOfAwaited := false
+				for awaitedKey := range p.awaited {
+					if len(awaitedKey) > len(newKey) && awaitedKey[len(newKey)] == '.' && awaitedKey[:len(newKey)] == newKey {
+						isParentOfAwaited = true
+						break
+					}
+				}
+
+				if !isParentOfAwaited {
+					unknown[newKey] = p.conv(v)
+				}
+
+				p.flattenDFS(subMap, newKey, found, unknown)
+			}
+		} else if _, ok := v.([]any); ok {
+			if isAwaited {
+				found[newKey] = p.conv(v)
+			} else {
+				unknown[newKey] = p.conv(v)
+			}
+		} else {
+			if isAwaited {
+				found[newKey] = p.conv(v)
+			} else {
+				unknown[newKey] = p.conv(v)
+			}
+		}
+	}
+}

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -1,0 +1,311 @@
+package json_test
+
+import (
+	"os"
+	"testing"
+
+	zfg "github.com/chaindead/zerocfg"
+	"github.com/chaindead/zerocfg/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		awaited map[string]bool
+		found   map[string]string
+		unknown map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "simple key-value",
+			input: `{"str": "name", "int": 1}`,
+			awaited: map[string]bool{
+				"str": true,
+			},
+			found: map[string]string{
+				"str": `name`,
+			},
+			unknown: map[string]string{
+				"int": `1`,
+			},
+		},
+		{
+			name: "nested",
+			input: `{
+                "host": "localhost",
+                "database": {
+                    "port": 5432,
+                    "credentials": {
+                        "username": "admin"
+                    }
+                }
+            }`,
+			awaited: map[string]bool{
+				"database.credentials.username": true,
+			},
+			found: map[string]string{
+				"database.credentials.username": `admin`,
+			},
+			unknown: map[string]string{
+				"host":          `localhost`,
+				"database.port": `5432`,
+			},
+		},
+		{
+			name:  "array",
+			input: `{"tags": ["tag1", "tag2", "tag3"]}`,
+			awaited: map[string]bool{
+				"tags": true,
+			},
+			found: map[string]string{
+				"tags": `["tag1","tag2","tag3"]`,
+			},
+		},
+		{
+			name:  "map within awaited key",
+			input: `{"db": {"host": "localhost", "port": 5432}}`,
+			awaited: map[string]bool{
+				"db": true,
+			},
+			found: map[string]string{
+				"db": `{"host":"localhost","port":5432}`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "awaited key within map",
+			input: `{"db": {"host": "localhost", "port": 5432}}`,
+			awaited: map[string]bool{
+				"db.host": true,
+			},
+			found: map[string]string{
+				"db.host": `localhost`,
+			},
+			unknown: map[string]string{
+				"db.port": "5432",
+			},
+		},
+		{
+			name:  "bool and null",
+			input: `{"flag": true, "value": null}`,
+			awaited: map[string]bool{
+				"flag":  true,
+				"value": true,
+			},
+			found: map[string]string{
+				"flag":  `true`,
+				"value": `null`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "numbers (float, exp, negative)",
+			input: `{"pi": 3.1415, "big": 1e6, "neg": -0.5}`,
+			awaited: map[string]bool{
+				"pi":  true,
+				"big": true,
+				"neg": true,
+			},
+			found: map[string]string{
+				"pi":  `3.1415`,
+				"big": `1e6`,
+				"neg": `-0.5`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "empty structures",
+			input: `{"emptyObj": {}, "emptyArr": []}`,
+			awaited: map[string]bool{
+				"emptyObj": true,
+				"emptyArr": true,
+			},
+			found: map[string]string{
+				"emptyObj": `{}`,
+				"emptyArr": `[]`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name: "escaped strings",
+			input: `{
+                "path": "C:\\\\Users\\\\Alice",
+                "quote": "\"To be\"",
+                "euro": "\u20AC"
+            }`,
+			awaited: map[string]bool{
+				"path":  true,
+				"quote": true,
+				"euro":  true,
+			},
+			found: map[string]string{
+				"path":  `C:\\Users\\Alice`,
+				"quote": `"To be"`,
+				"euro":  `€`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name: "nested arrays & objects",
+			input: `{
+                "users": [
+                    {"id": 1, "name": "Alice"},
+                    {"id": 2, "name": "Bob"}
+                ]
+            }`,
+			awaited: map[string]bool{
+				"users": true,
+			},
+			found: map[string]string{
+				"users": `[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "array element by index (await whole array)",
+			input: `{"tags": ["go", "json", "test"]}`,
+			awaited: map[string]bool{
+				"tags": true,
+			},
+			found: map[string]string{
+				"tags": `["go","json","test"]`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "duplicate keys",
+			input: `{"a": 1, "a": 2}`,
+			awaited: map[string]bool{
+				"a": true,
+			},
+			found: map[string]string{
+				"a": `2`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "key with dot character (await key itself)",
+			input: `{"a.b": {"c": 3}}`,
+			awaited: map[string]bool{
+				`a.b`: true,
+			},
+			found: map[string]string{
+				`a.b`: `{"c":3}`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:  "large integer",
+			input: `{"big": 9007199254740993}`,
+			awaited: map[string]bool{
+				"big": true,
+			},
+			found: map[string]string{
+				"big": `9007199254740993`,
+			},
+			unknown: map[string]string{},
+		},
+		{
+			name:    "json only bool",
+			input:   `true`,
+			wantErr: true,
+		},
+		{
+			name:    "json only string",
+			input:   `"hello"`,
+			wantErr: true,
+		},
+		{
+			name:    "json only number",
+			input:   `123`,
+			wantErr: true,
+		},
+		{
+			name:    "json only null",
+			input:   `null`,
+			wantErr: true,
+		},
+		{
+			name:    "json only array",
+			input:   `[1,2,3]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.found == nil {
+				tt.found = map[string]string{}
+			}
+			if tt.unknown == nil {
+				tt.unknown = map[string]string{}
+			}
+
+			path := tempFile(t, tt.input)
+
+			if tt.input == "" {
+
+				require.NotEqual(t, "", path, "tempFile should return a path even for empty content")
+			}
+			p := json.New(&path)
+
+			found, unknown, err := p.Parse(tt.awaited, zfg.ToString)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.found, found, "Found map mismatch")
+				assert.Equal(t, tt.unknown, unknown, "Unknown map mismatch")
+			}
+		})
+	}
+}
+
+func TestParse_Error(t *testing.T) {
+	path := tempFile(t, `{"invalid": "json",}`)
+	p := json.New(&path)
+
+	_, _, err := p.Parse(map[string]bool{}, zfg.ToString)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal json")
+}
+
+func TestParse_EmptyInputError(t *testing.T) {
+	path := tempFile(t, ``)
+	p := json.New(&path)
+
+	_, _, err := p.Parse(map[string]bool{}, zfg.ToString)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+func TestParse_FileNotExist(t *testing.T) {
+	nonExistentPath := "no_such_file.json"
+	p := json.New(&nonExistentPath)
+
+	found, unknown, err := p.Parse(map[string]bool{"some.key": true}, zfg.ToString)
+	require.NoError(t, err)
+	assert.Empty(t, found)
+	assert.Empty(t, unknown)
+}
+
+func tempFile(t *testing.T, data string) string {
+	f, err := os.CreateTemp("", "test-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(f.Name())
+	})
+
+	if data != "" {
+		_, err = f.WriteString(data)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, f.Close())
+
+	return f.Name()
+}


### PR DESCRIPTION
Adds a new parser to support loading configuration values from JSON files.

Includes:
- `json` package with the parser implementation.
- Comprehensive unit tests covering various JSON structures and edge cases.
- Fix for handling `null` values in the core `ToString` conversion function.