### PR TITLE
fix: support --name=value form in flag provider

### DIFF
--- a/flag/parse.go
+++ b/flag/parse.go
@@ -29,20 +29,28 @@ func parse(awaited map[string]bool, args []string) (found, unknown map[string]st
 		arg := args[i]
 
 		var name string
-		if strings.HasPrefix(arg, "-") {
-			name = arg[1:]
-		}
-
 		if strings.HasPrefix(arg, "--") {
 			name = arg[2:]
+		} else if strings.HasPrefix(arg, "-") {
+			name = arg[1:]
 		}
 
 		if name == "" {
 			continue
 		}
 
+		// Support the --name=value GNU form: split the value off the flag
+		// name so it is matched against the awaited key and not dropped.
+		var inlineValue string
+		if idx := strings.IndexByte(name, '='); idx >= 0 {
+			inlineValue = name[idx+1:]
+			name = name[:idx]
+		}
+
 		var value string
-		if i+1 < len(args) && len(args[i+1]) > 0 && args[i+1][0] != '-' {
+		if inlineValue != "" {
+			value = inlineValue
+		} else if i+1 < len(args) && len(args[i+1]) > 0 && args[i+1][0] != '-' {
 			value = args[i+1]
 			i++
 		}

--- a/flag/parse_test.go
+++ b/flag/parse_test.go
@@ -75,8 +75,22 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name: "empty args",
-			args: []string{},
+			name:    "empty args",
+			args:    []string{},
+		},
+		{
+			name:    "long flag with inline equals value",
+			args:    []string{"--name=value", "--other=foo"},
+			awaited: map[string]bool{"name": true, "other": true},
+			found:   map[string]string{"name": "value", "other": "foo"},
+			unknown: map[string]string{},
+		},
+		{
+			name:    "mixed space and inline equals values",
+			args:    []string{"--config", "config.yaml", "--port=5432"},
+			awaited: map[string]bool{"config": true, "port": true},
+			found:   map[string]string{"config": "config.yaml", "port": "5432"},
+			unknown: map[string]string{},
 		},
 	}
 


### PR DESCRIPTION
The flag parser only handled space separated values, so --log-level=debug was read as the key 'log-level=debug' and silently dropped into the unknown set with its value lost. The fix splits the value off on the first '=' so the GNU --flag=value form matches the awaited key and keeps its value.